### PR TITLE
Fixing cnf.py

### DIFF
--- a/aiger_cnf/cnf.py
+++ b/aiger_cnf/cnf.py
@@ -88,8 +88,8 @@ def aig2cnf(circ, *, outputs=None, fresh=None, force_true=True):
         if not isinstance(gate, aiger.aig.Inverter):
             continue
 
-        oldv = out2lit[name] = fresh(gate)
-        newv = gate2lit[gate]
+        oldv = out2lit[name]
+        newv = out2lit[name] = fresh(gate)
         clauses.append((-newv,  oldv))
         clauses.append((newv,  -oldv))
 


### PR DESCRIPTION
Hi Marcell,

Thank you very much for developing this tool.

I am a PhD student at Northwestern University researching circuit logic encryption. I got an incorrect result when I was using your tool to convert an aag file into CNF. After careful examination, I came up with a fix (as this commit) which solved my problem. 

Below is the aag file my group was working on. You can see the result difference between the old code and the new one. In my case, the old code resulted in four isolated clauses `(-13, 14), (13, -14), (-15, 16), (15, -16)` which I do not think is correct.

```
aag 14 4 0 4 10
2
4
6
8
11
13
18
28
10 9 5
12 7 3
14 9 5
16 7 3
18 17 15
20 7 2
22 18 9
24 19 8
26 25 23
28 26 21
i0 i1
i1 i2
i2 si1
i3 si2
o0 w1
o1 so1
o2 so2
o3 b
c
Generated by Yosys 0.9 (git sha1 UNKNOWN, gcc 7.5.0-3ubuntu1~18.04 -fPIC -Os)
```

Please merge this branch if you believe this is a correct fix. Feel free to contact me if you have any questions or concerns.

Best,
Guannan